### PR TITLE
[#3] Add documentation for existing code

### DIFF
--- a/src/Data/Type/Zahlen.hs
+++ b/src/Data/Type/Zahlen.hs
@@ -11,14 +11,14 @@ import Data.Type.Natural (Nat (S, Z))
 import Data.Type.Zahlen.Class
 import Data.Type.Zahlen.Definitions
 
-instance IsCommutativeRing Zahlen where
-  type Zero' = ('Pos 'Z)
-  type One' = ('Pos (S Z))
-  type Inv m = Inverse m
+--instance IsCommutativeRing Zahlen where
+--  type Zero' = ('Pos 'Z)
+--  type One' = ('Pos (S Z))
+--  type Inv m = Inverse m
 --   zeroIdentity :: forall x m. Absolute'' x :~: 'Z -> x + m :~: m
 --   zeroIdentity Refl = Refl `because` (Proxy )
 
-instance IsInteger Zahlen where
-  type Signum ('Pos m) = P
-  type Signum ('Neg m) = N
-  type Absolute'' (_ m) = m
+--instance IsInteger Zahlen where
+--  type Signum ('Pos m) = P
+--  type Signum ('Neg m) = N
+--  type Absolute'' (_ m) = m

--- a/src/Data/Type/Zahlen.hs
+++ b/src/Data/Type/Zahlen.hs
@@ -1,7 +1,24 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module Data.Type.Zahlen
     ( module Data.Type.Zahlen.Class
     , module Data.Type.Zahlen.Definitions
     ) where
 
+import Data.Type.Natural ( Nat(S, Z) )
+
 import Data.Type.Zahlen.Class
 import Data.Type.Zahlen.Definitions
+
+instance IsCommutativeRing Zahlen where
+  type Zero' = ('Pos 'Z)
+  type One' = ('Pos (S Z))
+  type Inv m = Inverse m
+--   zeroIdentity :: forall x m. Absolute'' x :~: 'Z -> x + m :~: m
+--   zeroIdentity Refl = Refl `because` (Proxy )
+
+instance IsInteger Zahlen where
+  type Signum ('Pos m) = P
+  type Signum ('Neg m) = N
+  type Absolute'' (_ m) = m

--- a/src/Data/Type/Zahlen.hs
+++ b/src/Data/Type/Zahlen.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds    #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Data.Type.Zahlen
@@ -6,7 +6,7 @@ module Data.Type.Zahlen
     , module Data.Type.Zahlen.Definitions
     ) where
 
-import Data.Type.Natural ( Nat(S, Z) )
+import Data.Type.Natural (Nat (S, Z))
 
 import Data.Type.Zahlen.Class
 import Data.Type.Zahlen.Definitions

--- a/src/Data/Type/Zahlen/Class/Arithmetic.hs
+++ b/src/Data/Type/Zahlen/Class/Arithmetic.hs
@@ -1,35 +1,25 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE EmptyCase            #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE InstanceSigs         #-}
-{-# LANGUAGE KindSignatures       #-}
-{-# LANGUAGE NoStarIsType         #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeInType           #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NoStarIsType        #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeInType          #-}
+{-# LANGUAGE TypeOperators       #-}
 
 module Data.Type.Zahlen.Class.Arithmetic where
- 
---import Data.Promotion.Prelude.Enum
+
+import Data.Kind (Type)
+import Data.Type.Equality ((:~:) (..))
+import Data.Typeable
+import Unsafe.Coerce
+
 import Data.Singletons.Prelude
 import Data.Singletons.Prelude.Enum
 import Data.Singletons.TH
-import Data.Typeable
-
-import Data.Type.Equality           ((:~:) (..))
 import Data.Type.Natural
 import Data.Type.Natural.Class.Arithmetic
-import Data.Type.Natural.Class.Order (leqTrans, leqAntisymm, leqRefl)
-import Data.Kind                    (Type)
-
+import Data.Type.Natural.Class.Order (leqAntisymm, leqRefl, leqTrans)
 import Proof.Propositional
-
-import Unsafe.Coerce
 
 import Data.Type.Zahlen.Definitions
 
@@ -40,6 +30,11 @@ posInjective
   -> n :~: m
 posInjective Refl = Refl
 
+negInjective
+  :: forall n m. Neg n :~: Neg m
+  -> n :~: m
+negInjective Refl = Refl
+
 posLemma
   :: forall n m. n :~: m
   -> Pos n :~: Pos m
@@ -49,11 +44,6 @@ negLemma
   :: forall n m. n :~: m
   -> Neg n :~: Neg m
 negLemma Refl = Refl
-
-negInjective
-  :: forall n m. Neg n :~: Neg m
-  -> n :~: m
-negInjective Refl = Refl
 
 plusCong
   :: forall (n :: Zahlen) (m :: Zahlen) (p :: Zahlen). n :~: m
@@ -87,17 +77,17 @@ absoluteIdem (SNeg n) = Refl
 
 zeroIdentity
   :: forall (m :: Zahlen). Sing m
-  -> (Pos Z) + m :~: m
-zeroIdentity (SPos n) = Refl
-zeroIdentity (SNeg SZ) = unsafeCoerce Refl
+  -> Pos Z + m :~: m
+zeroIdentity (SPos n)      = Refl
+zeroIdentity (SNeg SZ)     = unsafeCoerce Refl
 zeroIdentity (SNeg (SS n)) = Refl
 
 zeroIdentityR
   :: forall (m :: Zahlen). Sing m
-  -> m + (Pos Z) :~: m
+  -> m + Pos Z :~: m
 zeroIdentityR (SPos SZ) = Refl
 zeroIdentityR (SPos (SS n)) =
-  plusCong' (SS n) (SZ) (SS n) (plusZeroR (SS n))
+  plusCong' (SS n) SZ (SS n) (plusZeroR (SS n))
 zeroIdentityR (SNeg SZ) = unsafeCoerce Refl
 zeroIdentityR (SNeg (SS n)) = Refl
 
@@ -106,11 +96,11 @@ plusAssoc
   -> Sing n
   -> Sing p
   -> m + n + p :~: m + (n + p)
-plusAssoc (SPos SZ) (SPos SZ) (SPos SZ) = Refl
-plusAssoc (SPos SZ) (SPos (SS n)) (SPos SZ) = Refl
+plusAssoc (SPos SZ) (SPos SZ) (SPos SZ)         = Refl
+plusAssoc (SPos SZ) (SPos (SS n)) (SPos SZ)     = Refl
 plusAssoc (SPos SZ) (SPos (SS n)) (SPos (SS p)) = Refl
-plusAssoc (SPos (SS n)) (SPos SZ) (SPos SZ) = undefined
-plusAssoc m n p = undefined
+plusAssoc (SPos (SS n)) (SPos SZ) (SPos SZ)     = undefined
+plusAssoc m n p                                 = undefined
 
 class IsCommutativeRing z where
   type Zero' :: z

--- a/src/Data/Type/Zahlen/Class/Arithmetic.hs
+++ b/src/Data/Type/Zahlen/Class/Arithmetic.hs
@@ -111,3 +111,44 @@ plusAssoc (SPos SZ) (SPos (SS n)) (SPos SZ) = Refl
 plusAssoc (SPos SZ) (SPos (SS n)) (SPos (SS p)) = Refl
 plusAssoc (SPos (SS n)) (SPos SZ) (SPos SZ) = undefined
 plusAssoc m n p = undefined
+
+class IsCommutativeRing z where
+  type Zero' :: z
+  type One' :: z
+  type Inv (m :: z) :: z
+
+  oneIsNotZero :: One' :~: Zero' -> Void
+  associativity
+    :: forall x y z. Sing x
+    -> Sing y
+    -> Sing z
+    -> (x + y) + z :~: x + (y + z)
+  commutativity
+    :: forall x y. Sing x
+    -> Sing y
+    -> x + y :~: y + z
+  distr
+    :: forall x y z. Sing x
+    -> Sing y
+    -> Sing z
+    -> (x * (y + z)) :~: ((x * y) + (x * z))
+  zeroNeutral
+    :: forall x. Sing x
+    -> x + Zero' :~: x
+  oneNeutral
+    :: forall x. Sing x
+    -> x * One' :~: x
+  inverseAxiom
+    :: forall x. Sing x
+    -> (x + Inv x) :~: Zero'
+
+class IsCommutativeRing z => IsInteger z where
+  type Signum (m :: z) :: Sign
+  type Absolute'' (m :: z) :: Nat
+
+  zeroEquality :: (Absolute'' x ~ Absolute'' y, Absolute'' x ~ 'Z) => x :~: y
+  zeroEquality = unsafeCoerce Refl
+  zeroEquality' :: Absolute'' x :~: Absolute'' y -> Absolute'' x :~: 'Z -> x :~: y
+  zeroEquality' Refl Refl = unsafeCoerce Refl
+--  zeroIdentity :: forall x m. Absolute'' x :~: 'Z -> x + m :~: m
+--  zeroIdentity = Refl

--- a/src/Data/Type/Zahlen/Class/Arithmetic.hs
+++ b/src/Data/Type/Zahlen/Class/Arithmetic.hs
@@ -102,43 +102,44 @@ plusAssoc (SPos SZ) (SPos (SS n)) (SPos (SS p)) = Refl
 plusAssoc (SPos (SS n)) (SPos SZ) (SPos SZ)     = undefined
 plusAssoc m n p                                 = undefined
 
-class IsCommutativeRing z where
-  type Zero' :: z
-  type One' :: z
-  type Inv (m :: z) :: z
+--class IsCommutativeRing z where
+--  type Zero' :: z
+--  type One' :: z
+--  type Inv (m :: z) :: z
+--
+--  oneIsNotZero :: One' :~: Zero' -> Void
+--  associativity
+--    :: forall x y z. Sing x
+--    -> Sing y
+--    -> Sing z
+--    -> (x + y) + z :~: x + (y + z)
+--  commutativity
+--    :: forall x y. Sing x
+--    -> Sing y
+--    -> x + y :~: y + z
+--  distr
+--    :: forall x y z. Sing x
+--    -> Sing y
+--    -> Sing z
+--    -> (x * (y + z)) :~: ((x * y) + (x * z))
+--  zeroNeutral
+--    :: forall x. Sing x
+--    -> x + Zero' :~: x
+--  oneNeutral
+--    :: forall x. Sing x
+--    -> x * One' :~: x
+--  inverseAxiom
+--    :: forall x. Sing x
+--    -> (x + Inv x) :~: Zero'
 
-  oneIsNotZero :: One' :~: Zero' -> Void
-  associativity
-    :: forall x y z. Sing x
-    -> Sing y
-    -> Sing z
-    -> (x + y) + z :~: x + (y + z)
-  commutativity
-    :: forall x y. Sing x
-    -> Sing y
-    -> x + y :~: y + z
-  distr
-    :: forall x y z. Sing x
-    -> Sing y
-    -> Sing z
-    -> (x * (y + z)) :~: ((x * y) + (x * z))
-  zeroNeutral
-    :: forall x. Sing x
-    -> x + Zero' :~: x
-  oneNeutral
-    :: forall x. Sing x
-    -> x * One' :~: x
-  inverseAxiom
-    :: forall x. Sing x
-    -> (x + Inv x) :~: Zero'
+--class IsCommutativeRing z => IsInteger z where
+--  type Signum (m :: z) :: Sign
+--  type Absolute'' (m :: z) :: Nat
+--
+--  zeroEquality :: (Absolute'' x ~ Absolute'' y, Absolute'' x ~ 'Z) => x :~: y
+--  zeroEquality = unsafeCoerce Refl
+--  zeroEquality' :: Absolute'' x :~: Absolute'' y -> Absolute'' x :~: 'Z -> x :~: y
+--  zeroEquality' Refl Refl = unsafeCoerce Refl
 
-class IsCommutativeRing z => IsInteger z where
-  type Signum (m :: z) :: Sign
-  type Absolute'' (m :: z) :: Nat
-
-  zeroEquality :: (Absolute'' x ~ Absolute'' y, Absolute'' x ~ 'Z) => x :~: y
-  zeroEquality = unsafeCoerce Refl
-  zeroEquality' :: Absolute'' x :~: Absolute'' y -> Absolute'' x :~: 'Z -> x :~: y
-  zeroEquality' Refl Refl = unsafeCoerce Refl
 --  zeroIdentity :: forall x m. Absolute'' x :~: 'Z -> x + m :~: m
 --  zeroIdentity = Refl

--- a/src/Data/Type/Zahlen/Class/Order.hs
+++ b/src/Data/Type/Zahlen/Class/Order.hs
@@ -1,38 +1,28 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE EmptyCase            #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE InstanceSigs         #-}
-{-# LANGUAGE KindSignatures       #-}
-{-# LANGUAGE NoStarIsType         #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeInType           #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NoStarIsType        #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeInType          #-}
+{-# LANGUAGE TypeOperators       #-}
 
 module Data.Type.Zahlen.Class.Order where
 
---import Data.Promotion.Prelude.Enum
+import Data.Kind (Type)
+import Data.Type.Equality ((:~:) (..))
+import Data.Typeable
+import Unsafe.Coerce
+
 import Data.Singletons.Prelude
 import Data.Singletons.Prelude.Enum
 import Data.Singletons.TH
-import Data.Typeable
-
-import Data.Type.Equality           ((:~:) (..))
 import Data.Type.Natural
 import Data.Type.Natural.Class.Arithmetic
-import Data.Type.Natural.Class.Order (leqTrans, leqAntisymm, leqRefl)
-import Data.Kind                    (Type)
-
+import Data.Type.Natural.Class.Order (leqAntisymm, leqRefl, leqTrans)
 import Proof.Propositional
 
-import Unsafe.Coerce
-
+import Data.Type.Zahlen.Class.Arithmetic (negLemma, posLemma)
 import Data.Type.Zahlen.Definitions
-import Data.Type.Zahlen.Class.Arithmetic (posLemma, negLemma)
 
 -- Order
 
@@ -165,7 +155,7 @@ totality sing1 sing2 =
   case (sing1, sing2) of
     (SNeg n1, SNeg n2) ->
       case n1 %<= n2 of
-        STrue -> Right $ NegLeqNeg $ unsafeCoerce Witness
+        STrue  -> Right $ NegLeqNeg $ unsafeCoerce Witness
         SFalse -> Left $ NegLeqNeg $ unsafeCoerce Witness
     (SNeg n1, SPos n2) ->
       Left NegLeqPos
@@ -173,5 +163,5 @@ totality sing1 sing2 =
       Right NegLeqPos
     (SPos n1, SPos n2) ->
       case n1 %<= n2 of
-        STrue -> Left $ PosLeqPos $ unsafeCoerce Witness
+        STrue  -> Left $ PosLeqPos $ unsafeCoerce Witness
         SFalse -> Right $ PosLeqPos $ unsafeCoerce Witness

--- a/src/Data/Type/Zahlen/Definitions.hs
+++ b/src/Data/Type/Zahlen/Definitions.hs
@@ -182,10 +182,6 @@ singletons [d|
         False -> Neg $ fromInteger n
   |]
 
-natToZ :: Sing n -> Sing (Pos n)
-natToZ SZ     = SPos SZ
-natToZ (SS n) = SPos (SS n)
-
 zToNat :: Sing (Pos n) -> Sing n
 zToNat (SPos n) = n
 

--- a/src/Data/Type/Zahlen/Definitions.hs
+++ b/src/Data/Type/Zahlen/Definitions.hs
@@ -163,59 +163,6 @@ singletons [d|
         False -> Neg $ fromInteger n
   |]
 
-class IsCommutativeRing z where
-  type Zero' :: z
-  type One' :: z
-  type Inv (m :: z) :: z
-
-  oneIsNotZero :: One' :~: Zero' -> Void
-  associativity
-    :: forall x y z. Sing x
-    -> Sing y
-    -> Sing z
-    -> (x + y) + z :~: x + (y + z)
-  commutativity
-    :: forall x y. Sing x
-    -> Sing y
-    -> x + y :~: y + z
-  distr
-    :: forall x y z. Sing x
-    -> Sing y
-    -> Sing z
-    -> (x * (y + z)) :~: ((x * y) + (x * z))
-  zeroNeutral
-    :: forall x. Sing x
-    -> x + Zero' :~: x
-  oneNeutral
-    :: forall x. Sing x
-    -> x * One' :~: x
-  inverseAxiom
-    :: forall x. Sing x
-    -> (x + Inv x) :~: Zero'
-
-instance IsCommutativeRing Zahlen where
-  type Zero' = ('Pos 'Z)
-  type One' = ('Pos (S Z))
-  type Inv m = Inverse m
---   zeroIdentity :: forall x m. Absolute'' x :~: 'Z -> x + m :~: m
---   zeroIdentity Refl = Refl `because` (Proxy )
-
-class IsCommutativeRing z => IsInteger z where
-  type Signum (m :: z) :: Sign
-  type Absolute'' (m :: z) :: Nat
-
-  zeroEquality :: (Absolute'' x ~ Absolute'' y, Absolute'' x ~ 'Z) => x :~: y
-  zeroEquality = unsafeCoerce Refl
-  zeroEquality' :: Absolute'' x :~: Absolute'' y -> Absolute'' x :~: 'Z -> x :~: y
-  zeroEquality' Refl Refl = unsafeCoerce Refl
---  zeroIdentity :: forall x m. Absolute'' x :~: 'Z -> x + m :~: m
---  zeroIdentity = Refl
-
-instance IsInteger Zahlen where
-  type Signum ('Pos m) = P
-  type Signum ('Neg m) = N
-  type Absolute'' (_ m) = m
-
 natToZ :: Sing n -> Sing (Pos n)
 natToZ SZ     = SPos SZ
 natToZ (SS n) = SPos (SS n)

--- a/src/Data/Type/Zahlen/Definitions.hs
+++ b/src/Data/Type/Zahlen/Definitions.hs
@@ -47,7 +47,7 @@ singletons [d|
     :: Sign
     -> Sign
   opposite P = N
-  opposine N = P
+  opposite N = P
   |]
 
 singletons [d|
@@ -65,7 +65,7 @@ singletons [d|
     :: Zahlen
     -> Sign
   signOf (Pos _) = P
-  singOf (Neg _) = N
+  signOf (Neg _) = N
   |]
 
 singletons [d|

--- a/src/Data/Type/Zahlen/Definitions.hs
+++ b/src/Data/Type/Zahlen/Definitions.hs
@@ -29,6 +29,11 @@ import Unsafe.Coerce
 
 import Data.Kind (Constraint, Type)
 
+{-| We represent integers with two constructors @Pos :: Nat -> Zahlen@ and
+    @Neg :: Nat -> Zahlen@, such that @Pos n@ represents the integer /n/ and
+    @Neg n@ represents the integer /-n/. Note that zero has two representations
+    under this scheme.
+-}
 singletons [d|
   data Zahlen = Pos Nat | Neg Nat
     deriving (Show, Eq)
@@ -37,11 +42,13 @@ singletons [d|
 deriving instance Typeable 'Neg
 deriving instance Typeable 'Pos
 
+{-| The sign of a 'Zahlen'. -}
 singletons [d|
   data Sign = P | N
     deriving (Show, Eq)
   |]
 
+{-| Flip a sign. -}
 singletons [d|
   opposite
     :: Sign
@@ -50,6 +57,9 @@ singletons [d|
   opposite N = P
   |]
 
+{-| Get the sign of a 'Zahlen' as a 'Zahlen'. Note that the sign of either zero
+    representation is @Pos Z@.
+-}
 singletons [d|
   signZ
     :: Zahlen
@@ -60,6 +70,9 @@ singletons [d|
   signZ (Neg Z)     = Pos Z
   |]
 
+{-| Get the sign of a 'Zahlen' as a 'Sign'. Note that the sign of @Pos Z@ is @P@
+    and the sign of @Neg z@ is @N@.
+-}
 singletons [d|
   signOf
     :: Zahlen
@@ -68,6 +81,7 @@ singletons [d|
   signOf (Neg _) = N
   |]
 
+{-| Get the sign of a product from the signs of the factors. -}
 singletons [d|
   signMult
     :: Sign
@@ -77,6 +91,7 @@ singletons [d|
   signMult N s2 = opposite N
   |]
 
+{-| Construct a @Zahlen@ from a @Sign@ and @Nat@. |-}
 singletons [d|
   signToZ
     :: Sign
@@ -86,6 +101,7 @@ singletons [d|
   signToZ N = Neg
   |]
 
+{-| Get the absolute value of a @Zahlen@ as a @Nat@. |-}
 singletons [d|
   absolute'
     :: Zahlen
@@ -94,6 +110,7 @@ singletons [d|
   absolute' (Neg n) = n
   |]
 
+{-| Get the absolute value of a @Zahlen@ as a @Zahlen@. |-}
 singletons [d|
   absolute
     :: Zahlen
@@ -102,6 +119,7 @@ singletons [d|
   absolute (Neg n) = Pos n
   |]
 
+{-| Negate a @Zahlen@. |-}
 singletons [d|
   inverse
     :: Zahlen
@@ -129,6 +147,7 @@ singletons [d|
         False -> Neg $ toEnum n
   |]
 
+{-| Subtract two @Nat@s to get a @Zahlen@. |-}
 singletons [d|
   sub
     :: Nat

--- a/src/Data/Type/Zahlen/Definitions.hs
+++ b/src/Data/Type/Zahlen/Definitions.hs
@@ -40,13 +40,17 @@ deriving instance Typeable 'Pos
 singletons [d|
   data Sign = P | N
     deriving (Show, Eq)
+  |]
 
+singletons [d|
   opposite
     :: Sign
     -> Sign
   opposite P = N
   opposine N = P
+  |]
 
+singletons [d|
   signZ
     :: Zahlen
     -> Zahlen
@@ -54,20 +58,26 @@ singletons [d|
   signZ (Neg (S n)) = Neg (S Z)
   signZ (Pos Z)     = Pos Z
   signZ (Neg Z)     = Pos Z
+  |]
 
+singletons [d|
   signOf
     :: Zahlen
     -> Sign
   signOf (Pos _) = P
   singOf (Neg _) = N
+  |]
 
+singletons [d|
   signMult
     :: Sign
     -> Sign
     -> Sign
   signMult P s2 = s2
   signMult N s2 = opposite N
+  |]
 
+singletons [d|
   signToZ
     :: Sign
     -> Nat
@@ -77,19 +87,22 @@ singletons [d|
   |]
 
 singletons [d|
-
   absolute'
     :: Zahlen
     -> Nat
   absolute' (Pos n) = n
   absolute' (Neg n) = n
+  |]
 
+singletons [d|
   absolute
     :: Zahlen
     -> Zahlen
   absolute (Pos n) = Pos n
   absolute (Neg n) = Pos n
+  |]
 
+singletons [d|
   inverse
     :: Zahlen
     -> Zahlen


### PR DESCRIPTION
The code is documented and cleaned. Other changes: 
* Removing the redundant `natToZ` function.
* Commenting out the typeclasses `IsCommutativeRing` and `IsInteger` typeclasses, since they are not really necessary at the moment.

See the commit messages for more context.